### PR TITLE
ポートフォワーディング

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     mariadb:
         image: 'mariadb:10'
         ports:
-            - '${FORWARD_DB_PORT:-3309}:3309'
+            - '${FORWARD_DB_PORT:-3309}:3306'
         environment:
             MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
             MYSQL_ROOT_HOST: '%'


### PR DESCRIPTION
レビューの際、｢この設定では外部からDBに接続出来ない｣というご指摘を受け、WindowsPC本体にインストールしてあるMySQLとの競合を防ぎたかったので、調べて修正してみました。
Windowsからアクセスできるということは、｢PCの3309ポートと仮想環境の3306ポートが結びつき、解決できた｣という解釈で合っていますか？

![image](https://github.com/kosaboten/greeting/assets/146682275/c82a07c9-01bd-4693-a584-f034d8c2e0c6)
